### PR TITLE
fix: build with unix line endings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./lib",
     "strict": true,
     "allowJs": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "newLine": "lf"
   },
   "include": ["index.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Added `tsconfig` compiler option to output unix LF line endings. Fixes output script not running on macOS.

@justintaylor-dev not sure if it would still work on Windows though, so will need further testing.

Discussion in main repo issue: https://github.com/hyperbrew/bolt-cep/issues/20