### PR TITLE
Invalid command tweaks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -124,6 +124,8 @@ const init = async () => {
     div();
   } else {
     console.error(c.red("Incorrect Command"));
+    // Give the user a visual of what the issue was in their command
+    const appMessage = `App name provided: ${name || ""}`;
     const templateMessage = `Template name provided: ${templateStr || ""}`;
     console.error(name?.length > 0 ? c.green(appMessage) : c.red(appMessage));
     console.error(template ? c.green(templateMessage) : c.red(templateMessage));


### PR DESCRIPTION
Added a few tweaks to your invalid command logs by using the framework array to log examples and also added a visual aid to show the user what they got right and wrong in their command. I also added a check for the destination incase the user used './' for their app name as is the usual way of saying "create the app in this folder". 