### PR TITLE
Replace default "Bolt CEP" names in CEP config with user-defined extension name

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,17 @@ const frameworks = [
   { name: "svelte", pretty: "Svelte" },
 ];
 
+const slugify = (...args: string[]): string => {
+  const value = args.join(" ");
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9 ]/g, "")
+    .replace(/\s+/g, "-");
+};
+
 const div = () =>
   console.info(c.grey("--------------------------------------------------"));
 const space = () => console.info("");
@@ -117,6 +128,10 @@ const init = async () => {
     // Remove Debug Lines from config
     replaceInFile(path.join(dest, "cep.config.ts"), [
       [/.*(\/\/ BOLT-CEP-DEBUG-ONLY).*/g, ""],
+      // Replace default "Bolt CEP" entries with user-provided extension name
+      [/(?<=displayName:\s\")[^\"]*(?=\")/gim, name],
+      [/(?<=panelDisplayName:\s\")[^\"]*(?=\")/gim, name],
+      [/(?<=id:\s\"com\.)[^\"]*(?=\.cep\")/gim, slugify(name)],
     ]);
 
     // Add .gitignore


### PR DESCRIPTION
Hi Justin, finding that I'm often creating several extensions with display names of "Bolt CEP" from not having run a `yarn build` after manually adjusting the cep.config file which causes only the first to display in app. We could skip the need for the user to insert the name they've already chosen for their extension like so: