### PR TITLE
Additional apps (`bolt-cep` #104)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com//hyper-brew/create-bolt-cep/issues"
   },
   "dependencies": {
-    "@clack/prompts": "^0.4.3",
+    "@clack/prompts": "^0.7.0",
     "bolt-cep": "^1.1.9",
     "execa": "^5.1.1",
     "fs-extra": "^10.0.1",

--- a/src/lib/bolt.ts
+++ b/src/lib/bolt.ts
@@ -18,6 +18,7 @@ export async function installBolt({
   const globalBolt = path.join(root, "..", "bolt-cep");
 
   let bolt = fs.existsSync(localBolt) ? localBolt : globalBolt;
+  // bolt = globalBolt; // for use when testing against dev version of `bolt-cep`
   const isSymlink = fs.lstatSync(bolt).isSymbolicLink();
   bolt = isSymlink ? fs.realpathSync(bolt) : bolt;
 
@@ -106,12 +107,14 @@ export async function installBolt({
     ].forEach((file) => fs.removeSync(path.join(jsFolder, file)));
 
     // remove references
-    replaceInFile(cepConfig, [
-      [`iconDarkNormal: "./src/assets/light-icon.png",\n`, ""],
-      [`iconNormal: "./src/assets/dark-icon.png",\n`, ""],
-      [`iconDarkNormalRollOver: "./src/assets/light-icon.png",\n`, ""],
-      [`iconNormalRollOver: "./src/assets/dark-icon.png",\n`, ""],
-    ]);
+    // TODO: fix this.. as it currently breaks CEP panel.
+    // empty string becomes `undefined` in `manifest.xml` which prevents panel from appearing in Extensions menu of host apps
+    // replaceInFile(cepConfig, [
+    //   [`iconDarkNormal: "./src/assets/light-icon.png",\n`, ""],
+    //   [`iconNormal: "./src/assets/dark-icon.png",\n`, ""],
+    //   [`iconDarkNormalRollOver: "./src/assets/light-icon.png",\n`, ""],
+    //   [`iconNormalRollOver: "./src/assets/dark-icon.png",\n`, ""],
+    // ]);
 
     [path.join("main", "index.tsx"), path.join("main", "index.ts")].forEach(
       (file) => {

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -12,7 +12,7 @@ export type Options = {
   git: boolean;
 };
 
-export type Framework = typeof frameworks[number];
+export type Framework = (typeof frameworks)[number];
 export const frameworks = ["svelte", "react", "vue"] as const;
 export const frameworkOptions: OptionsArray<Framework> = [
   { value: "svelte", label: "Svelte" },
@@ -20,18 +20,31 @@ export const frameworkOptions: OptionsArray<Framework> = [
   { value: "vue", label: "Vue" },
 ];
 
-export type App = typeof apps[number];
-export const apps = ["aeft", "ppro", "phxs", "ilst", "anim"] as const;
+export type App = (typeof apps)[number];
+export const apps = [
+  "aeft",
+  "ame",
+  "audt",
+  "anim",
+  "idsn",
+  "ilst",
+  "kbrg",
+  "phxs",
+  "ppro",
+] as const;
 export const appOptions: OptionsArray<App> = [
   { value: "aeft", label: "After Effects" },
   { value: "ppro", label: "Premiere Pro" },
   { value: "phxs", label: "Photoshop" },
   { value: "ilst", label: "Illustrator" },
+  { value: "idsn", label: "InDesign" },
   { value: "anim", label: "Animate" },
-  // { value: "encd", label: "Media Encoder" }, ??
+  { value: "ame", label: "Media Encoder" },
+  { value: "kbrg", label: "Bridge" },
+  { value: "audt", label: "Audition" },
 ];
 
-export type Template = typeof templates[number];
+export type Template = (typeof templates)[number];
 export const templates = ["demo", "skeleton"] as const;
 export const templateOptions: OptionsArray<Template> = [
   {

--- a/src/lib/parse-args.ts
+++ b/src/lib/parse-args.ts
@@ -113,7 +113,7 @@ export async function parseArgs(): Promise<string | Options> {
       template: isTemplateString(argv.template) ? argv.template : "demo",
       apps: isAppStringArray(argv.apps)
         ? argv.apps
-        : ["aeft", "anim", "ilst", "phxs", "ppro"],
+        : (apps as unknown as App[]),
       // git: argv.initializeGit ?? false,
       git: false, // TODO: initGit() isn't working
       installDeps: argv.installDependencies ?? false,

--- a/src/lib/ts-morph.ts
+++ b/src/lib/ts-morph.ts
@@ -1,4 +1,4 @@
-import { ts, Project, WriterFunction } from "ts-morph";
+import { ts, Project, WriterFunction, DefaultClause } from "ts-morph";
 import { App, OptionsArray } from "./options";
 
 export function updateObjectProperty(
@@ -50,6 +50,13 @@ export function updateSwitchStatement(
       clause.remove();
     }
   });
+
+  const hasAnim = selectedApps.find((x) => x.value === "anim");
+  if (!hasAnim) {
+    const clauses = switchStatement.getClauses();
+    const defaultClause = clauses.find((x) => x instanceof DefaultClause);
+    defaultClause?.remove();
+  }
 
   const typeAlias = sourceFile.getTypeAliasOrThrow("Scripts");
   const values = selectedApps.map((x) => x.value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,20 +7,20 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
   integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
 
-"@clack/core@^0.1.6":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@clack/core/-/core-0.1.7.tgz#a51433d57be1e3534681ba7f7e14483804a2884b"
-  integrity sha512-hyrb8/QlcC2vJO5ZL19/Fl3YHwfPK2o2TuW1zczzFO7lBUQWePGHhJu2wc6AJOjtpbyppylCLWnFFY3sGfLJSg==
+"@clack/core@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@clack/core/-/core-0.3.3.tgz#233ccebf779aa5a66fc68ee48df5e58cd226fd94"
+  integrity sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==
   dependencies:
     picocolors "^1.0.0"
     sisteransi "^1.0.5"
 
-"@clack/prompts@^0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@clack/prompts/-/prompts-0.4.3.tgz#4f10d3cd478c5bbc9dec5b7fa3a24afb487731ba"
-  integrity sha512-R3Ws19DbdqKarkfbvqde0v9Cfi7o/mferY4CF4ca4VOrrUXUKP0NOofKEMDzuehEdlImiaC5qs9UKnfU3p2IxQ==
+"@clack/prompts@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@clack/prompts/-/prompts-0.7.0.tgz#6aaef48ea803d91cce12bc80811cfcb8de2e75ea"
+  integrity sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==
   dependencies:
-    "@clack/core" "^0.1.6"
+    "@clack/core" "^0.3.3"
     picocolors "^1.0.0"
     sisteransi "^1.0.5"
 
@@ -488,6 +488,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-unicode-supported@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
+  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
 
 is-windows@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
`create-bolt-cep` half of adding apps mentioned in [#104](https://github.com/hyperbrew/bolt-cep/issues/104) !

Tested by running `yarn build` then `node dist/index.js` and following prompts, such that I built a svelte skeleton with just the new apps. Then, to test ExtendScript, I updated `main.svelte` to:

```svelte
<script lang="ts">
  import { csi, evalES } from "../lib/utils/bolt";

  //* Demonstration of Traditional string eval-based ExtendScript Interaction
  const jsxTest = () => {
    console.log(evalES(`helloWorld("${csi.getApplicationID()}")`));
  };
</script>

<h1 style="color: #ff5b3b;">Welcome to Bolt CEP!</h1>

<button on:click={jsxTest}> ExtendScript </button>
```

and to each `[host].ts` file, added something similar as the skeleton app removes our `helloWorld`:

```ts
export const helloWorld = () => {
  alert("Hello from Media Encoder");
};
```